### PR TITLE
Add Steeltoe 4.1 to staging environment

### DIFF
--- a/SteeltoeInitializr-Staging.yaml
+++ b/SteeltoeInitializr-Staging.yaml
@@ -1,17 +1,19 @@
 ---
 steeltoeVersion:
   type: single-select
-  default: 4.0.x
+  default: 4.1.x
   values:
   - id: 3.3.x
     name: Steeltoe 3.3.x (stable)
   - id: 4.0.x
     name: Steeltoe 4.0.x (stable)
+  - id: 4.1.x
+    name: Steeltoe 4.1.x (stable)
   - id: 4.x-main-x
     name: Steeltoe 4.x (unstable)
 dotNetFramework:
   type: single-select
-  default: net8.0
+  default: net10.0
   values:
   - id: net6.0
     name: .NET 6.0 (Out of support)
@@ -42,7 +44,7 @@ dependencies:
       name: Use Spring Cloud Config Server
       description: Adds a client for Spring Cloud Config Server to configuration.
     - id: configuration-encryption
-      steeltoeVersionRange: '[4.0]'
+      steeltoeVersionRange: '[4.x]'
       name: Use encrypted configuration
       description: Adds decryption of encrypted settings in configuration.
     - id: configuration-placeholder


### PR DESCRIPTION
Includes bugfix: Encryption can't be selected for Steeltoe Unstable.

<img width="1578" height="576" alt="image" src="https://github.com/user-attachments/assets/a516bb7a-4dec-4692-8e7a-c0a042788e57" />
